### PR TITLE
Change broker rewrite callback to handle resolution too

### DIFF
--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -5,7 +5,9 @@
 
 use std::error::Error;
 use std::future::Future;
+use std::io;
 use std::marker::PhantomData;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -14,7 +16,7 @@ use std::time::{Duration, Instant};
 use futures_channel::oneshot;
 use futures_util::FutureExt;
 
-use crate::client::{BrokerAddr, Client, ClientContext, DefaultClientContext, OAuthToken};
+use crate::client::{Client, ClientContext, DefaultClientContext, OAuthToken};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext, RDKafkaLogLevel};
 use crate::consumer::ConsumerGroupMetadata;
 use crate::error::{KafkaError, KafkaResult, RDKafkaErrorCode};
@@ -156,8 +158,8 @@ impl<C: ClientContext + 'static> ClientContext for FutureProducerContext<C> {
         self.wrapped_context.error(error, reason);
     }
 
-    fn rewrite_broker_addr(&self, addr: BrokerAddr) -> BrokerAddr {
-        self.wrapped_context.rewrite_broker_addr(addr)
+    fn resolve_broker_addr(&self, host: &str, port: u16) -> Result<Vec<SocketAddr>, io::Error> {
+        self.wrapped_context.resolve_broker_addr(host, port)
     }
 
     fn generate_oauth_token(


### PR DESCRIPTION
Instead of offering a callback that allows rewriting broker addresses before DNS resolution, offer a callback that handles the entire DNS resolution process. This is strictly more powerful than the previous callback. Users can still rewrite addresses before DNS resolution, if they so choose, but they can also plug in their own DNS resolver, or inspect and/or modify addresses after DNS resolution.